### PR TITLE
manifest.in and setup.cfg updates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include ponzi_auth *.txt *.html *.css *.zcml *.js *.css
+include *.txt README.* Makefile *.ini

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,9 @@
 zip_ok = false
 
 [nosetests]
-where=repoze/bfg/formish
+where=pyramid_formish
 match=^test
 nocapture=1
-cover-package=repoze.bfg.formish
+cover-package=pyramid_formish
 cover-erase=1
 


### PR DESCRIPTION
Nosetests failed because of setup.cfg referring to repoze.bfg.formish
